### PR TITLE
Add resource limits

### DIFF
--- a/nextflow.config
+++ b/nextflow.config
@@ -2,12 +2,11 @@ process {
     executor = 'slurm'
     cache = 'lenient'
     resourceLimits {
-        // These limits are the maximum across all partitions and QOS
-        // on the cluster. Thus, these are mostly taken from the bonus QOS, which
-        // has the most lenient resource limits.
-        // See `sacctmgr show QOS Format=name%15,MaxTRESPU%110,MaxWall`
-        cpus = 196
+        // These limits are the maximum for one single job on the cluster, and as such are constrained by the resources on the largest node on the cluster,
+        // which is currently the Cooper Lake. See the output from `sinfo --Node --format '%N %.7m %c'`
+        cpus = 192
         memory = 3011.GB
+        // Time limit is set to the bonus QoS wall time, since bonus is the most permissive QoS. See `sacctmgr show qos Format=Name,MaxWall`
         time = 14.days
     }
 }

--- a/nextflow.config
+++ b/nextflow.config
@@ -6,8 +6,8 @@ process {
         // on the cluster. Thus, these are mostly taken from the bonus QOS, which
         // has the most lenient resource limits.
         // See `sacctmgr show QOS Format=name%15,MaxTRESPU%110,MaxWall`
-        cpus = 6896
-        memory = 45548110.M
+        cpus = 196
+        memory = 3011.GB
         time = 14.days
     }
 }

--- a/nextflow.config
+++ b/nextflow.config
@@ -1,6 +1,15 @@
 process {
     executor = 'slurm'
     cache = 'lenient'
+    resourceLimits {
+        // These limits are the maximum across all partitions and QOS
+        // on the cluster. Thus, these are mostly taken from the bonus QOS, which
+        // has the most lenient resource limits.
+        // See `sacctmgr show QOS Format=name%15,MaxTRESPU%110,MaxWall`
+        cpus = 6896
+        memory = 45548110.M
+        time = 14.days
+    }
 }
 executor {
     queueSize = 100


### PR DESCRIPTION
See: https://www.nextflow.io/docs/latest/process.html#process-resourcelimits.

In the future it might make sense to be more opinionated, and define a "regular", "long", "bonus" process label so that we get more granular limits and users don't have to re-define them. However that will be a separate PR.